### PR TITLE
Delete note about particular virtualbox version support. No longer actual.

### DIFF
--- a/test01.md
+++ b/test01.md
@@ -11,8 +11,6 @@ Learn some command line, server and http tools
 
 1. [Linux Command Line Basics](https://www.udacity.com/course/linux-command-line-basics--ud595)
 
-> Note: Currently (October 2017), you should install version 5.1 of VirtualBox. Later versions are not yet compatible with Vagrant. 
-
 2. [Configuring Linux Web Servers](https://www.udacity.com/course/configuring-linux-web-servers--ud299)
 
 3. [Networking for Web Developers](https://www.udacity.com/course/networking-for-web-developers--ud256)


### PR DESCRIPTION
Hi
https://github.com/hashicorp/vagrant/issues/9090 - issue "Support for VirtualBox 5.2" were fixed and support was added https://github.com/hashicorp/vagrant/pull/8955.
As I can see, the latest Vagrant 2.0.1 works with latest virtualbox 5.2.4 - both packages were downloaded from official websites.