### PR TITLE
tasks: Suggest a pre-OOP and post-OOP tasks

### DIFF
--- a/tasks/README.md
+++ b/tasks/README.md
@@ -22,6 +22,20 @@
 
 Tasks above are unidirectional linked list.
 
+### New tasks suggested for the remote phase
+
+These below can be added to the course only
+if approved by the community.
+
+* [pre-OOP JS](js-pre-oop.md) -
+  would come before [Object-Oriented JavaScript](js-oop.md)
+  to give students some experience of possibly bad coding.
+  Time to complete estimate 1-2 hours.
+* [post-OOP JS](js-post-oop.md) -
+  would come after [Object-Oriented JavaScript](js-oop.md).
+  Basically same as **pre-OOP JS** but this time students
+  are armed with JS OOP knowledge.
+
 ## Meetup supported (intramural) phase
 
 ### Major stream
@@ -36,7 +50,7 @@ Tasks above are unidirectional linked list.
 ### Supplementaries (workshops)
 
 1. [Advanced git](git-advanced.md)
-1. JS OOP
+1. JS OOP (see [issue #101](https://github.com/kottans/frontend/issues/101)
 
 ## To Be Assigned
 

--- a/tasks/js-post-oop.md
+++ b/tasks/js-post-oop.md
@@ -1,0 +1,44 @@
+[![MIT Licensed][icon-mit]][license]
+[![Ideas and useful links][icon-ideas]][ideas]
+[![Awesome][icon-awesome]][awesome]
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+[![Gitter][icon-chat]][chat]
+
+# OOP exercise
+
+Now you know a lot about JavaScript OOP. Remember that
+tiny JS world? Time to use your new power.
+
+1. Re-build your tiny JS world model you forked from
+   [here](https://github.com/OleksiyRudenko/a-tiny-JS-world).
+   This time use your favourite JS OOP methods to keep
+   your code DRY and SOLID.
+
+2. When done then do the following
+
+   * in your `kottans-frontend` repo `README.md` add a header
+     **post-OOP JS**, add the link to your repo and also
+     - name (at least) one thing that was new to you
+     - name (at least) one thing that surprised you
+     - name (at least) one thing you intend to use in the future
+     - how OOP course you passed affected your coding
+
+   * share your progress with others -
+     send a message in gitter channel (_post-OOP JS task finished!_)
+     with the link to your
+     repo and `@/all` tag and also ask mentors to make
+     a code review
+
+## Done?
+
+➡️ Go forward to [Offline Web Applications](app-design-offline.md)
+
+[icon-chat]: https://badges.gitter.im/Kottans/frontend.svg
+[icon-mit]: https://img.shields.io/badge/license-MIT-blue.svg
+[icon-ideas]: https://img.shields.io/badge/google--doc-ideas-ff69b4.svg
+[icon-awesome]: https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
+
+[license]: https://github.com/Kottans/web/blob/master/LICENSE.md
+[awesome]: https://github.com/sindresorhus/awesome#front-end-development
+[ideas]: https://docs.google.com/spreadsheets/d/1bZJhYjK3VHOS2HmQb2Fs4aHfEBt8mp1F09j9nEEDaqE/edit#gid=818017811
+[chat]: https://gitter.im/Kottans/frontend?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge

--- a/tasks/js-pre-oop.md
+++ b/tasks/js-pre-oop.md
@@ -1,0 +1,38 @@
+[![MIT Licensed][icon-mit]][license]
+[![Ideas and useful links][icon-ideas]][ideas]
+[![Awesome][icon-awesome]][awesome]
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+[![Gitter][icon-chat]][chat]
+
+# Building a tiny world
+
+1. Build a tiny JS world model following the instructions
+   [here](https://github.com/OleksiyRudenko/a-tiny-JS-world).
+
+2. When done then do the following
+
+   * in your `kottans-frontend` repo `README.md` add a header
+     **pre-OOP JS** and add link to your repo
+
+   * share your progress with others -
+     send a message in gitter channel (_A tiny world task finished!_)
+     with the link to your
+     repo and `@/all` tag and also ask mentors to make
+     a code review
+
+   * read one or two articles on OOP under the links in
+     [this repo](https://github.com/OleksiyRudenko/a-tiny-JS-world/blob/master/README.md#learn-on-your-own)
+
+## Done?
+
+➡️ Go forward to [Object-Oriented JavaScript](js-oop.md)
+
+[icon-chat]: https://badges.gitter.im/Kottans/frontend.svg
+[icon-mit]: https://img.shields.io/badge/license-MIT-blue.svg
+[icon-ideas]: https://img.shields.io/badge/google--doc-ideas-ff69b4.svg
+[icon-awesome]: https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
+
+[license]: https://github.com/Kottans/web/blob/master/LICENSE.md
+[awesome]: https://github.com/sindresorhus/awesome#front-end-development
+[ideas]: https://docs.google.com/spreadsheets/d/1bZJhYjK3VHOS2HmQb2Fs4aHfEBt8mp1F09j9nEEDaqE/edit#gid=818017811
+[chat]: https://gitter.im/Kottans/frontend?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge

--- a/tasks/js-pre-oop.md
+++ b/tasks/js-pre-oop.md
@@ -4,7 +4,7 @@
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 [![Gitter][icon-chat]][chat]
 
-# Building a tiny world
+# Building a Tiny JS World
 
 1. Build a tiny JS world model following the instructions
    [here](https://github.com/OleksiyRudenko/a-tiny-JS-world).
@@ -12,10 +12,10 @@
 2. When done then do the following
 
    * in your `kottans-frontend` repo `README.md` add a header
-     **pre-OOP JS** and add link to your repo
+     **A tiny JS world** and add link to your repo
 
    * share your progress with others -
-     send a message in gitter channel (_A tiny world task finished!_)
+     send a message in gitter channel (_A tiny JS world task finished!_)
      with the link to your
      repo and `@/all` tag and also ask mentors to make
      a code review


### PR DESCRIPTION
A suggestion of possible tasks. Partially resolving #106 (item 5 therein), implementing [this idea](https://github.com/kottans/frontend/issues/92#issuecomment-429547230), and idea under item 2 (post-check) from [this comment](https://github.com/kottans/frontend/issues/92#issuecomment-429550520).

Links to suggested tasks are added to the technical tasks listing in `tasks/README.md` under section **New tasks suggested for the remote phase** as candidates to inclusion into the course syllabus (which is `contents.md` after PR #104 approval).