### PR TITLE
Changing link to udacity Object Oriented JS

### DIFF
--- a/tasks/js-oop.md
+++ b/tasks/js-oop.md
@@ -5,7 +5,7 @@
 
 # Object-Oriented JavaScript
 
-1. [Object Oriented JS](https://www.udacity.com/course/object-oriented-javascript--ud015)
+1. [Object Oriented JS](https://classroom.udacity.com/courses/ud015)
 1. [codewars](https://www.codewars.com/) - register, join Kottans clan and reach 7 kyu.
 
 If you honestly finished all the previous steps then go ahead and share it with others


### PR DESCRIPTION
Seems like udacity started redirection on old  Object Oriented JS course, but the old course is still available from another link.

I think we need to update js-oop.md as soon as possible @yevhenorlov @OleksiyRudenko @IgorKurkov @AMashoshyna