### PR TITLE
Add Stage 0 finishers listing template & link it from friends app task

### DIFF
--- a/students/stage0-finishers.md
+++ b/students/stage0-finishers.md
@@ -1,0 +1,47 @@
+# Frontend Course Stage 0 (self-study) finishers
+
+Course Stage 0 (self-study) comprises
+[14 tasks (0 to 13)](https://github.com/kottans/frontend/blob/master/contents.md),
+of which
+- 12 are mandatory including
+  - 6 regular tasks
+  - 6 practical tasks/real projects with code review
+- 2 are optional
+
+Once you're eligible to list yourself here, please, add
+a table row below for yourself following the example.
+
+If you completed mandatory tasks only, no problem, go ahead.
+You may change your record if you decide to complete
+optionals later.
+
+_Make sure the file contains an empty line at the end._
+_When editing file via GitHub add two newlines at the file end._
+
+Fields description:
+ * **Date** is the date you have completed mandatory tasks
+   or all of the tasks
+ * **Course profile** is your nick name with a link to your
+   course repo (`kottans-frontend`)
+ * **R** means **Regulars** and is a number of regular tasks completed;
+   normally says `6`; if `5` or lesser then you can
+   be inquired for the reasons
+ * **P** means **Practicals** and is a number of practical tasks completed;
+   normally says `6`; if `5` or lesser then you can
+   be inquired for the reasons
+ * **O** means **Optionals** and is a number of optional tasks
+   completed;
+   `0` is OK; `2` qualifies you for a special badge
+   provided all mandatory tasks are completed
+ * **B** means **Badges** and is a number of badges earned during
+   the course Stage 0; `0` is OK; anything above that is a plus
+ * **Comment** is for optional comments and reasons to skip any mandatory
+   tasks
+
+Use the first table row as a template.
+
+## Finishers
+
+|    Date    | Course profile | M | P | O | B | Comment |
+| ---------- | -------------- | - | - | - | - | ------- |
+| 2018-12-31 | [example-username](https://github.com/example-username/kottans-frontend) | 6 | 6 | 2 | 0 | --- |

--- a/students/stage0-finishers.md
+++ b/students/stage0-finishers.md
@@ -21,14 +21,13 @@ _When editing file via GitHub add two newlines at the file end._
 Fields description:
  * **Date** is the date you have completed mandatory tasks
    or all of the tasks
- * **Course profile** is your nick name with a link to your
+ * **Course repo** is your nick name with a link to your
    course repo (`kottans-frontend`)
  * **R** means **Regulars** and is a number of regular tasks completed;
    normally says `6`; if `5` or lesser then you can
    be inquired for the reasons
  * **P** means **Practicals** and is a number of practical tasks completed;
-   normally says `6`; if `5` or lesser then you can
-   be inquired for the reasons
+   normally says `6`; if `5` or lesser then give a reason in **Comment**
  * **O** means **Optionals** and is a number of optional tasks
    completed;
    `0` is OK; `2` qualifies you for a special badge
@@ -37,11 +36,13 @@ Fields description:
    the course Stage 0; `0` is OK; anything above that is a plus
  * **Comment** is for optional comments and reasons to skip any mandatory
    tasks
+ * **Performance** is intended for mentors team use, e.g.
+   to specify performance badges granted
 
 Use the first table row as a template.
 
 ## Finishers
 
-|    Date    | Course profile | R | P | O | B | Comment |
-| ---------- | -------------- | - | - | - | - | ------- |
-| 2018-12-31 | [example-username](https://github.com/example-username/kottans-frontend) | 6 | 6 | 2 | 0 | --- |
+|    Date    | Course repo    | R | P | O | B | Comment | Performance |
+| ---------- | -------------- | - | - | - | - | ------- | ----------- |
+| 2018-12-31 | [example-username](https://github.com/example-username/kottans-frontend) | 6 | 6 | 2 | 0 | --- | |

--- a/students/stage0-finishers.md
+++ b/students/stage0-finishers.md
@@ -42,6 +42,6 @@ Use the first table row as a template.
 
 ## Finishers
 
-|    Date    | Course profile | M | P | O | B | Comment |
+|    Date    | Course profile | R | P | O | B | Comment |
 | ---------- | -------------- | - | - | - | - | ------- |
 | 2018-12-31 | [example-username](https://github.com/example-username/kottans-frontend) | 6 | 6 | 2 | 0 | --- |

--- a/tasks/friends-app.md
+++ b/tasks/friends-app.md
@@ -71,10 +71,19 @@ When complete do the following:
 
 __Congratulations! 🎉__
 
+* [ ] Have you finished all mandatory tasks?
+* [ ] Are practical tasks get reviewed and
+      PRs are merged into
+      [frontend-2019-homeworks](https://github.com/kottans/frontend-2019-homeworks)
+      repo `master`?
+
 You have finished __Stage 0__ of the course!
 
 Go ahead and post a celebration sticker or dancing gif
 in the [course channel][chat].
+
+... and a tiny thing to do yet.
+[List yourself among course Stage 0 finishers](../students/stage0-finishers).
 
 ⤴️ Back to [Contents](../contents.md)
 

--- a/tasks/friends-app.md
+++ b/tasks/friends-app.md
@@ -83,7 +83,7 @@ Go ahead and post a celebration sticker or dancing gif
 in the [course channel][chat].
 
 ... and a tiny thing to do yet.
-[List yourself among course Stage 0 finishers](../students/stage0-finishers).
+[List yourself among course Stage 0 finishers](../students/stage0-finishers.md).
 
 ⤴️ Back to [Contents](../contents.md)
 


### PR DESCRIPTION
We have first finisher. Time to establish a list of Stage 0 finishers.

The list will help 
- to know finishers and probably adjust course offline stage start date
- to know whom to conduct interview with in the first place
- to take badges into consideration if any
- to endorse those who finished all tasks including optionals with a
  [![Kottans-Student-Course-progress-grinder](https://img.shields.io/badge/%3D(%5E.%5E)%3D-Course%20grinder-green.svg)](https://github.com/kottans/kottans/blob/master/endorsements.md) badge
- have a source for the offline stage course students list, built by students themselves

Please, review and suggest improvements.