### PR TITLE
Update JS Basics task with a fallback recommendation

### DIFF
--- a/tasks/js-basics.md
+++ b/tasks/js-basics.md
@@ -11,6 +11,13 @@
    - finish first half of the course (11 lessons) and save a screenshot
    - note that for _Intermediate Algorithms Scripting: **Pig Latin**_ exercise English letter **Y** is considered a consonant
    - use hints available on freecodecamp at each exercise as the first resort when you feel stuck
+   - if you find this task difficult and need hints and googling from the very beginning consider passing simpler tasks first:
+     - [Basic JavaScript](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/basic-javascript/)
+     - [ES6 Challenges](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/es6/) - at least
+       till **Write Concise Declarative Functions with ES6**
+     - [Basic Data Structures](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/basic-data-structures/)
+     - [Basic Algorithm Scripting](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/basic-algorithm-scripting/)
+     - [Functional Programming](https://learn.freecodecamp.org/javascript-algorithms-and-data-structures/functional-programming/)
 
 Finish the subtasks (1) and (2) above.
 


### PR DESCRIPTION
Almost 30% of students that reached **JS Basics** tasks do not survive **JS Basics** and **JS DOM** tasks.
Both require to complete **freecodecamp Intermediate Algorithm Scripting Challenges**.

The hypotheses is that many have no clue how to save themselves with a fallback strategy, some pass Intermediate Algorithms heavily relying on hints and code examples without deep understanding the code.

The proposed change is an attempt give such students some guidance on learning curve sloping and also offers selected modules from freecodecamp range.

This also partially resolves #230 