### PR TITLE
Brought back 'index.js only' necessity

### DIFF
--- a/tasks/app-design-offline.md
+++ b/tasks/app-design-offline.md
@@ -22,7 +22,7 @@ do the following after you're done:
 1. You did an extra effort! Go ahead
    share your progress with others –
    post a message in [course channel][chat]:
-   `Offline Web Apps — #done` (or `Offline Web Apps — #p2p-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `Offline Web Apps — #done` (or `Offline Web Apps — #p2p_done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. Study Extra Materials below to improve your skills.
    If you feel it affects your overall course performance consider
    reverting to those later e.g. when you have all mandatory tasks completed.

--- a/tasks/app-design-performance.md
+++ b/tasks/app-design-performance.md
@@ -46,7 +46,7 @@ do the following after you're done:
 1. You did an extra effort! Go ahead
    share your progress with others –
    post a message in the [course channel][chat]:
-   `Website Performance Optimization — #done` (or `Website Performance Optimization — #p2p-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `Website Performance Optimization — #done` (or `Website Performance Optimization — #p2p_done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. Study Extra Materials below to improve your skills.
    If you feel it affects your overall course performance consider
    reverting to those later e.g. when you have all mandatory tasks completed.

--- a/tasks/friends-app.md
+++ b/tasks/friends-app.md
@@ -79,7 +79,7 @@ When complete do the following:
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in the [course channel][chat]:
-   `Friends App — #done` (or `Friends App — #p2p-pr-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `Friends App — #done` (or `Friends App — #p2p_done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. You have completed the last tasks section of offline course stage.
    We shall appreciate your feedback on this section especially
    if you're doing this course from Ukraine.

--- a/tasks/git-collaboration.md
+++ b/tasks/git-collaboration.md
@@ -28,7 +28,7 @@ When complete do the following:
 1. You did lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:
-   `Git Collaboration — #done` (or `Git Collaboration — #p2p-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `Git Collaboration — #done` (or `Git Collaboration — #p2p_done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. Study Extra Materials below to improve your skills.
    If you feel it affects your overall course performance consider
    reverting to those later e.g. when you have all mandatory tasks completed.

--- a/tasks/html-css-intro.md
+++ b/tasks/html-css-intro.md
@@ -26,7 +26,7 @@ When complete do the following:
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:
-   `Intro to HTML and CSS — #done` (or `Intro to HTML and CSS — #p2p-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `Intro to HTML and CSS — #done` (or `Intro to HTML and CSS — #p2p_done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. Study Extra Materials below to improve your skills.
    If you feel it affects your overall course performance consider
    reverting to those later e.g. when you have all mandatory tasks completed.

--- a/tasks/html-css-responsive.md
+++ b/tasks/html-css-responsive.md
@@ -29,7 +29,7 @@ When complete do the following:
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:
-   `Responsive Web Design — #done` (or `Responsive Web Design — #p2p-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `Responsive Web Design — #done` (or `Responsive Web Design — #p2p_done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. Study Extra Materials below to improve your skills.
    If you feel it affects your overall course performance consider
    reverting to those later e.g. when you have all mandatory tasks completed.

--- a/tasks/js-basics.md
+++ b/tasks/js-basics.md
@@ -44,7 +44,7 @@ When complete do the following:
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:
-   `JS Basics — #done` (or `JS Basics — #p2p-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `JS Basics — #done` (or `JS Basics — #p2p_done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. Study Extra Materials below to improve your skills.
    If you feel it affects your overall course performance consider
    reverting to those later e.g. when you have all mandatory tasks completed.

--- a/tasks/js-dom.md
+++ b/tasks/js-dom.md
@@ -46,7 +46,7 @@ When complete do the following:
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:
-   `DOM — #done` (or `DOM — #p2p-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `DOM — #done` (or `DOM — #p2p_done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. You will require code review for your subtask (3):
    - If you are a **p2p course** student, please, follow [these instructions](https://github.com/kottans/frontend-2019-p2p/blob/master/CONTRIBUTING.md)
    - If you are a student of the **offline** Kottans course, please, follow [these instructions](https://github.com/kottans/frontend-2019-homeworks/blob/master/README.md)

--- a/tasks/js-oop.md
+++ b/tasks/js-oop.md
@@ -28,7 +28,7 @@ When complete do the following:
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:
-   `Object Oriented JS — #done`(or `Object Oriented JS — #p2p-pr-done` if you are p2p course student)  and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `Object Oriented JS — #done`(or `Object Oriented JS — #p2p_done` if you are p2p course student)  and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. You will require code review for a coding subtask from (1)
    - If you are a **p2p course** student, please, follow [these instructions](https://github.com/kottans/frontend-2019-p2p/blob/master/CONTRIBUTING.md)
    - If you are a student of the **offline** Kottans course, please, follow [these instructions](https://github.com/kottans/frontend-2019-homeworks/blob/master/README.md)
@@ -41,7 +41,7 @@ When you finish this task you can proceed to the next one.
 
 ## Extra materials
 
-### OOP part: 
+### OOP part:
 
 - [Understanding ECMAScript 6. Block Bindings](https://leanpub.com/understandinges6/read/#leanpub-auto-block-bindings)
 - [Рoзуміння ECMAScript 6. Розділ "Блочне зв'язування"](https://understandinges6.denysdovhan.com/manuscript/01-Block-Bindings.html)

--- a/tasks/js-post-oop.md
+++ b/tasks/js-post-oop.md
@@ -26,7 +26,7 @@ When complete do the following:
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:
-   `OOP Exercise — #done` (or `OOP Exercise — #p2p-done` if you are p2p course student)
+   `OOP Exercise — #done` (or `OOP Exercise — #p2p_done` if you are p2p course student)
    and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. Study Extra Materials below to improve your skills and
    read an article or two on OOP under the links in

--- a/tasks/js-post-oop.md
+++ b/tasks/js-post-oop.md
@@ -18,12 +18,16 @@ tiny JS world? Time to use your new power.
 
 When complete do the following:
 1. You will require code review for this task:
-   - If you are a **p2p course** student, please, follow [these instructions](https://github.com/kottans/frontend-2019-p2p/blob/master/CONTRIBUTING.md)
-   - If you are a student of the **offline** Kottans course, please, follow [these instructions](https://github.com/kottans/frontend-2019-homeworks/blob/master/README.md)
+   - If you are a **p2p course** student, please,
+   follow [these instructions](https://github.com/kottans/frontend-2019-p2p/blob/master/CONTRIBUTING.md)
+   - If you are a student of the **offline** Kottans course, please,
+   follow [these instructions](https://github.com/kottans/frontend-2019-homeworks/blob/master/README.md)
+   - Note, that especially this task you require to put a single file (**index.js only**) in your homework repo.
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:
-   `OOP Exercise — #done` (or `OOP Exercise — #p2p-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `OOP Exercise — #done` (or `OOP Exercise — #p2p-done` if you are p2p course student)
+   and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. Study Extra Materials below to improve your skills and
    read an article or two on OOP under the links in
    [this repo](https://github.com/OleksiyRudenko/a-tiny-JS-world/blob/master/README.md#learn-on-your-own)

--- a/tasks/js-post-oop.md
+++ b/tasks/js-post-oop.md
@@ -22,7 +22,9 @@ When complete do the following:
    follow [these instructions](https://github.com/kottans/frontend-2019-p2p/blob/master/CONTRIBUTING.md)
    - If you are a student of the **offline** Kottans course, please,
    follow [these instructions](https://github.com/kottans/frontend-2019-homeworks/blob/master/README.md)
-   - Note, that especially this task you require to put a single file (**index.js only**) in your homework repo.
+   - Note, that especially this task requires you to submit
+   a single file (`index.js` **only**) to the
+   `frontend-2019-homeworks` or `frontend-2019-p2p` repo for code review.
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:

--- a/tasks/js-pre-oop.md
+++ b/tasks/js-pre-oop.md
@@ -16,7 +16,9 @@ When complete do the following:
 1. You will require code review for this task:
    - If you are a **p2p course** student, please, follow [these instructions](https://github.com/kottans/frontend-2019-p2p/blob/master/CONTRIBUTING.md)
    - If you are a student of the **offline** Kottans course, please, follow [these instructions](https://github.com/kottans/frontend-2019-homeworks/blob/master/README.md)
-   - Note, that especially this task you require to put a single file (**index.js only**) in your homework repo.
+   - Note, that especially this task requires you to submit
+   a single file (`index.js` **only**) to the
+   `frontend-2019-homeworks` or `frontend-2019-p2p` repo for code review.
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:

--- a/tasks/js-pre-oop.md
+++ b/tasks/js-pre-oop.md
@@ -20,7 +20,7 @@ When complete do the following:
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:
-   `A Tiny JS World — #done` (or `A Tiny JS World — #p2p-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `A Tiny JS World — #done` (or `A Tiny JS World — #p2p_done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. Read one or two articles on OOP under the links in
    [this repo](https://github.com/OleksiyRudenko/a-tiny-JS-world/blob/master/README.md#learn-on-your-own)
 

--- a/tasks/js-pre-oop.md
+++ b/tasks/js-pre-oop.md
@@ -16,6 +16,7 @@ When complete do the following:
 1. You will require code review for this task:
    - If you are a **p2p course** student, please, follow [these instructions](https://github.com/kottans/frontend-2019-p2p/blob/master/CONTRIBUTING.md)
    - If you are a student of the **offline** Kottans course, please, follow [these instructions](https://github.com/kottans/frontend-2019-homeworks/blob/master/README.md)
+   - Note, that especially this task you require to put a single file (**index.js only**) in your homework repo.
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:

--- a/tasks/linux-cli-http.md
+++ b/tasks/linux-cli-http.md
@@ -44,7 +44,7 @@ When complete do the following:
 1. If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in [course channel][chat]:
-   `Linux CLI and HTTP — #done` (or `Linux CLI and HTTP — #p2p-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `Linux CLI and HTTP — #done` (or `Linux CLI and HTTP — #p2p_done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 1. Study Extra Materials below to improve your skills.
    If you feel it affects your overall course performance consider
    reverting to those later e.g. when you have all mandatory tasks completed.

--- a/tasks/memory-pair-game.md
+++ b/tasks/memory-pair-game.md
@@ -35,7 +35,7 @@ When complete do the following:
 1. You did a lot already! If you honestly finished all the previous steps then go ahead
    and share it with others –
    post a message in the [course channel][chat]:
-   `Memory Pair Game — #done` (or `Memory Pair Game — #p2p-done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
+   `Memory Pair Game — #done` (or `Memory Pair Game — #p2p_done` if you are p2p course student) and add the link to your repo. **This step is important, as it helps mentors to track your progress!**
 
 When you finish this task you can proceed to the next one.
 


### PR DESCRIPTION
After the last update description of '**index.js only**' necessity was missed (pre and post OOP).
Not sure about putting it in the right place.