### PR TITLE
upd the link to Udacity git course

### DIFF
--- a/tasks/git-intro.md
+++ b/tasks/git-intro.md
@@ -7,7 +7,7 @@
 
 Get familiar with Git and GitHub.
 
- 1. Finish the course [How to use Git and GitHub](https://www.udacity.com/course/how-to-use-git-and-github--ud775)
+ 1. Finish the course [Version Control with Git](https://www.udacity.com/course/version-control-with-git--ud123)
 
     You may resort to subtitles/closed captions and
     to auto-translated subtitles in particular if you feel


### PR DESCRIPTION
Old link [How to use Git and GitHub](https://www.udacity.com/course/how-to-use-git-and-github--ud775) is redirecting to:
[Version Control with Git](https://www.udacity.com/course/version-control-with-git--ud123)
I'm proposing to replace name and link in the [Git and GitHub](https://github.com/kottans/frontend/blob/master/tasks/git-intro.md) task list.

