### PR TITLE
js-basics: Change link to the course

### DIFF
--- a/tasks/js-basics.md
+++ b/tasks/js-basics.md
@@ -5,7 +5,7 @@
 
 # JavaScript Basics
 
-1. [Intro to JS](https://www.udacity.com/course/intro-to-javascript--ud803)
+1. [Intro to JS](https://classroom.udacity.com/courses/ud803)
 
 1. FreeCodeCamp exercises. Complete the modules below and save screenshots for each module.
    Use hints available on freecodecamp at each exercise as the first resort when you feel stuck.


### PR DESCRIPTION
Old link exposed two courses - basics and nanodegree that might confuse students.