### PR TITLE
Merge 'Video' and '2021 Video' columns in SCHEDULE.md

### DIFF
--- a/SCHEDULE.md
+++ b/SCHEDULE.md
@@ -1,28 +1,28 @@
 # Frontend Course 2022
 
-| Date | Time | Module | Topic | Lecturer / Moderator | Cover lecturer | Summary | Slides | Video | 2021 Video | Home task |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-01.11.2022|19:00| |Вступна лекція до курсу|[Artem Sychov](https://github.com/suchov)|||||
-xx.xx.2022|12:00|HTML/CSS, JS DOM | Стандарти W3C and WHATWG, Розмітка HTML, Вступ в CSS, Сітки|[Viktor Yakubiv](https://github.com/viktor-yakubiv)||||[Лекція1](https://www.youtube.com/watch?v=xogSwtgiEJ0); [Лекція2](https://www.youtube.com/watch?v=7Q7jEa5h3FY)||
-xx.xx.2022|12:00|HTML/CSS, JS DOM | Графіка в інтернеті, А11Y та форми, робота з контентом|[Viktor Yakubiv](https://github.com/viktor-yakubiv)||||[Лекція3](https://www.youtube.com/watch?v=0l7ikOmdGGQ)|||
-xx.xx.2022|12:00|HTML/CSS, JS DOM | DOM and Layout Trees|[Nastia M.](https://github.com/AMashoshyna)|||||
-xx.xx.2022|12:00|HTML/CSS, JS DOM | Cookies(печеньки), document.cookie, how browser works 101|[Oleksii B.](https://github.com/Roophee)|||||
-xx.xx.2022|12:00|YDKJS|Scope, Closure|[Roman H.](https://github.com/Roman-Halenko)|||||
-xx.xx.2022|12:00|YDKJS|Objects & this|[Oleksii B.](https://github.com/Roophee)|||||
-xx.xx.2022|12:00|YDKJS|Prototype|[Nastia M.](https://github.com/AMashoshyna)|||||
-xx.xx.2022|12:00|YDKJS|Types Grammar|[Vladyslav Z.](https://github.com/what1s1ove)|||||
-xx.xx.2022|12:00|YDKJS|Callback/Promise|[Listochkin](https://github.com/listochkin)|||||
-xx.xx.2022|12:00|YDKJS|Async/Await|[Listochkin](https://github.com/listochkin)|||||
-xx.xx.2022|12:00|YDKJS|ESNext API/Generators|[Listochkin](https://github.com/listochkin)|||||
-xx.xx.2022|12:00|Framework|Побудова структури додатку, бізнес-процеси||||||[Частина 1](https://www.youtube.com/watch?v=yrQFB0o9-7s&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=26)|
-xx.xx.2022|12:00|Framework|Рекурсії для рендерінгу елементів|[Nastia M.](https://github.com/AMashoshyna)|||||
-xx.xx.2022|12:00|Framework|Networking. Використання зовнішніх даних у додатку|[Oleksii B.](https://github.com/Roophee)|||||[Частина 3](https://www.youtube.com/watch?v=Q27TVN3OUi8&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=29); [Q&A сесія](https://www.youtube.com/watch?v=AU2YiSt6lR8&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=30)|
-xx.xx.2022|12:00|Framework|Маштабування додатку||||||[Частина 4.1](https://www.youtube.com/watch?v=r375E7H6QeA&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=31); [Частина 4.2](https://www.youtube.com/watch?v=IGXWKcJt2Fc&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=32); [Q&A сесія](https://www.youtube.com/watch?v=Y418sgGslXU&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=33); [AMA сесія](https://www.youtube.com/watch?v=JCp1HV2OqG4&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=34)|
-xx.xx.2022|12:00|Framework|Ефекти, події, їх місце у життєвому циклі|[Nastia M.](https://github.com/AMashoshyna)|||||[Частина 5](https://www.youtube.com/watch?v=pw-I9SNLhcA&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=35)|
-xx.xx.2022|12:00|Framework|Потоки даних. Стан додатку||||||[Частина 6](https://www.youtube.com/watch?v=iXv7KvOxKxU&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=36); [Q&A сесія](https://www.youtube.com/watch?v=0hqdEfsDX60&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=37)|
-xx.xx.2022|12:00|Framework|Upgrade додатку до сучасного стану||||||[Частина 7](https://www.youtube.com/watch?v=NsZvZxB7HQI&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=38); [AMA сесія](https://www.youtube.com/watch?v=z0i8qEu12-c&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=39)|
-xx.xx.2022|12:00|Typescript|Навіщо нам типізація?|[Volodymyr Stelmakh](https://github.com/stelmakh)|||||
-xx.xx.2022|12:00|Typescript|Типи на кожен день|[Volodymyr Stelmakh](https://github.com/stelmakh)|||||
-xx.xx.2022|12:00|Typescript|Going deeper|[Volodymyr Stelmakh](https://github.com/stelmakh)|||||
-xx.xx.2022|12:00|Typescript|Мігруємо з JS на TS|[Volodymyr Stelmakh](https://github.com/stelmakh)|||||
-xx.xx.2022|12:00| |Випускний|[Artem Sychov](https://github.com/suchov)|||||
+| Date | Time | Module | Topic | Lecturer / Moderator | Cover lecturer | Summary | Slides | Video | Home task |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+01.11.2022|19:00| |Вступна лекція до курсу|[Artem Sychov](https://github.com/suchov)||||
+xx.xx.2022|12:00|HTML/CSS, JS DOM | Стандарти W3C and WHATWG, Розмітка HTML, Вступ в CSS, Сітки|[Viktor Yakubiv](https://github.com/viktor-yakubiv)||||[Лекція1](https://www.youtube.com/watch?v=xogSwtgiEJ0); [Лекція2](https://www.youtube.com/watch?v=7Q7jEa5h3FY)|
+xx.xx.2022|12:00|HTML/CSS, JS DOM | Графіка в інтернеті, А11Y та форми, робота з контентом|[Viktor Yakubiv](https://github.com/viktor-yakubiv)||||[Лекція3](https://www.youtube.com/watch?v=0l7ikOmdGGQ)||
+xx.xx.2022|12:00|HTML/CSS, JS DOM | DOM and Layout Trees|[Nastia M.](https://github.com/AMashoshyna)||||
+xx.xx.2022|12:00|HTML/CSS, JS DOM | Cookies(печеньки), document.cookie, how browser works 101|[Oleksii B.](https://github.com/Roophee)||||
+xx.xx.2022|12:00|YDKJS|Scope, Closure|[Roman H.](https://github.com/Roman-Halenko)||||
+xx.xx.2022|12:00|YDKJS|Objects & this|[Oleksii B.](https://github.com/Roophee)||||
+xx.xx.2022|12:00|YDKJS|Prototype|[Nastia M.](https://github.com/AMashoshyna)||||
+xx.xx.2022|12:00|YDKJS|Types Grammar|[Vladyslav Z.](https://github.com/what1s1ove)||||
+xx.xx.2022|12:00|YDKJS|Callback/Promise|[Listochkin](https://github.com/listochkin)||||
+xx.xx.2022|12:00|YDKJS|Async/Await|[Listochkin](https://github.com/listochkin)||||
+xx.xx.2022|12:00|YDKJS|ESNext API/Generators|[Listochkin](https://github.com/listochkin)||||
+xx.xx.2022|12:00|Framework|Побудова структури додатку, бізнес-процеси|||||[Частина 1](https://www.youtube.com/watch?v=yrQFB0o9-7s&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=26)|
+xx.xx.2022|12:00|Framework|Рекурсії для рендерінгу елементів|[Nastia M.](https://github.com/AMashoshyna)||||
+xx.xx.2022|12:00|Framework|Networking. Використання зовнішніх даних у додатку|[Oleksii B.](https://github.com/Roophee)||||[Частина 3](https://www.youtube.com/watch?v=Q27TVN3OUi8&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=29); [Q&A сесія](https://www.youtube.com/watch?v=AU2YiSt6lR8&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=30)|
+xx.xx.2022|12:00|Framework|Маштабування додатку|||||[Частина 4.1](https://www.youtube.com/watch?v=r375E7H6QeA&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=31); [Частина 4.2](https://www.youtube.com/watch?v=IGXWKcJt2Fc&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=32); [Q&A сесія](https://www.youtube.com/watch?v=Y418sgGslXU&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=33); [AMA сесія](https://www.youtube.com/watch?v=JCp1HV2OqG4&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=34)|
+xx.xx.2022|12:00|Framework|Ефекти, події, їх місце у життєвому циклі|[Nastia M.](https://github.com/AMashoshyna)||||[Частина 5](https://www.youtube.com/watch?v=pw-I9SNLhcA&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=35)|
+xx.xx.2022|12:00|Framework|Потоки даних. Стан додатку|||||[Частина 6](https://www.youtube.com/watch?v=iXv7KvOxKxU&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=36); [Q&A сесія](https://www.youtube.com/watch?v=0hqdEfsDX60&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=37)|
+xx.xx.2022|12:00|Framework|Upgrade додатку до сучасного стану|||||[Частина 7](https://www.youtube.com/watch?v=NsZvZxB7HQI&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=38); [AMA сесія](https://www.youtube.com/watch?v=z0i8qEu12-c&list=PLS8sEUxbfFY_eoMYj8tifTn83xv_VgnSd&index=39)|
+xx.xx.2022|12:00|Typescript|Навіщо нам типізація?|[Volodymyr Stelmakh](https://github.com/stelmakh)||||
+xx.xx.2022|12:00|Typescript|Типи на кожен день|[Volodymyr Stelmakh](https://github.com/stelmakh)||||
+xx.xx.2022|12:00|Typescript|Going deeper|[Volodymyr Stelmakh](https://github.com/stelmakh)||||
+xx.xx.2022|12:00|Typescript|Мігруємо з JS на TS|[Volodymyr Stelmakh](https://github.com/stelmakh)||||
+xx.xx.2022|12:00| |Випускний|[Artem Sychov](https://github.com/suchov)||||


### PR DESCRIPTION
I am not sure in this, in general as well as after checking the file history. On the other hand, I find 2 columns too detailed and would rather merge them indicating the year of lecture video in parentheses.

I could also offer a linear layout instead of table but don't find this the highest priority for now.