### PR TITLE
Remove DOM lecture from the Schedule

### DIFF
--- a/SCHEDULE.md
+++ b/SCHEDULE.md
@@ -8,7 +8,7 @@
 ~24.11.2022~|~19:00~|HTML/CSS, JS DOM|Графіка в інтернеті, А11Y та форми, робота з контентом|~[Viktor Yakubiv](https://github.com/viktor-yakubiv)~|||[О. Островний: Зображення, форми, доступність](https://www.youtube.com/watch?v=7Q7jEa5h3FY) (2021)|
 24.11.2022|19:00<br>2 год.|HTML/CSS, JS DOM|Основи макетування, Flexbox, Grid|[Viktor Yakubiv](https://github.com/viktor-yakubiv)|||[О. Островний: HTML/CSS](https://youtu.be/xogSwtgiEJ0?t=7418) (2021, 2:03:38–2:54:46)|[Форма замовлення](tasks/html-form.md)
 |||HTML/CSS, JS DOM|DOM and Layout Trees|~[Nastia M.](https://github.com/AMashoshyna)~|||[Х. Ландвитович: DOM](https://youtu.be/sSLSp7uz3Mo) (2021)|–
-xx.xx.2022|12:00|HTML/CSS, JS DOM | Cookies(печеньки), document.cookie, how browser works 101|[Oleksii B.](https://github.com/Roophee)||[Х. Ландвитович: Як працює браузер](https://www.youtube.com/watch?v=0l7ikOmdGGQ) (2021)|
+xx.xx.2022|12:00|HTML/CSS, JS DOM | Cookies(печеньки), document.cookie, how browser works 101|[Oleksii B.](https://github.com/Roophee)|||[Х. Ландвитович: Як працює браузер](https://www.youtube.com/watch?v=0l7ikOmdGGQ) (2021)|
 xx.xx.2022|12:00|YDKJS|Scope, Closure|[Roman H.](https://github.com/Roman-Halenko)|||
 xx.xx.2022|12:00|YDKJS|Objects & this|[Oleksii B.](https://github.com/Roophee)|||
 xx.xx.2022|12:00|YDKJS|Prototype|[Nastia M.](https://github.com/AMashoshyna)|||

--- a/SCHEDULE.md
+++ b/SCHEDULE.md
@@ -7,7 +7,7 @@
 17.11.2022|19:00<br>1.5 год.|HTML/CSS, JS DOM|Основи CSS|[Viktor Yakubiv](https://github.com/viktor-yakubiv)|[Основи CSS — конспект](notes/css.md)||[В. Якубів: Основи CSS](https://youtu.be/LDMr5UFtC6g) (2022)<br><br>[О. Островний: HTML/CSS](https://youtu.be/xogSwtgiEJ0?t=4772) (2021, 1:19:32–2:03:38)|[Форма замовлення](tasks/html-form.md)
 ~24.11.2022~|~19:00~|HTML/CSS, JS DOM|Графіка в інтернеті, А11Y та форми, робота з контентом|~[Viktor Yakubiv](https://github.com/viktor-yakubiv)~|||[О. Островний: Зображення, форми, доступність](https://www.youtube.com/watch?v=7Q7jEa5h3FY) (2021)|
 24.11.2022|19:00<br>2 год.|HTML/CSS, JS DOM|Основи макетування, Flexbox, Grid|[Viktor Yakubiv](https://github.com/viktor-yakubiv)|||[О. Островний: HTML/CSS](https://youtu.be/xogSwtgiEJ0?t=7418) (2021, 2:03:38–2:54:46)|[Форма замовлення](tasks/html-form.md)
-xx.xx.2022|12:00|HTML/CSS, JS DOM | DOM and Layout Trees|[Nastia M.](https://github.com/AMashoshyna)|||
+|||HTML/CSS, JS DOM|DOM and Layout Trees|~[Nastia M.](https://github.com/AMashoshyna)~|||[Х. Ландвитович: DOM](https://youtu.be/sSLSp7uz3Mo) (2021)|–
 xx.xx.2022|12:00|HTML/CSS, JS DOM | Cookies(печеньки), document.cookie, how browser works 101|[Oleksii B.](https://github.com/Roophee)||[Х. Ландвитович: Як працює браузер](https://www.youtube.com/watch?v=0l7ikOmdGGQ) (2021)|
 xx.xx.2022|12:00|YDKJS|Scope, Closure|[Roman H.](https://github.com/Roman-Halenko)|||
 xx.xx.2022|12:00|YDKJS|Objects & this|[Oleksii B.](https://github.com/Roophee)|||


### PR DESCRIPTION
Nastia cannot handle the lecture. Removing the lecture from the schedule and replacing it with the video from last year.

This is chained on top of #456 